### PR TITLE
Implement repo sync script and rename references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# jaro_tooth
+# jaro_core
 
 ## 🟢 Starten van de AI-dashboard CLI
 
-Om het AI-controlecentrum van JARO-TOOTH te starten, gebruik je het volgende script:
+Om het AI-controlecentrum van JARO-CORE te starten, gebruik je het volgende script:
 
 ```bash
 python interface/dashboard_cli.py

--- a/core/rollback_module.py
+++ b/core/rollback_module.py
@@ -1,4 +1,4 @@
-"""Rollback module voor JARO-TOOTH.
+"""Rollback module voor JARO-CORE.
 
 Dit script herstelt een eerdere versie van ``user_config.json`` door een
 back-up uit de map ``backups`` te kiezen. Het kan zowel zelfstandig

--- a/data/log_001.json
+++ b/data/log_001.json
@@ -1,0 +1,146 @@
+{
+  "memory_name": "jasper_vonk_core",
+  "generated": "2025-07-17T23:37:51.952041Z",
+  "files": [
+    {
+      "path": "README.md",
+      "memory_path": "README.md"
+    },
+    {
+      "path": "modules/braindump_module.py",
+      "memory_path": "ai_modules/braindump_module.py"
+    },
+    {
+      "path": "modules/habit_tracker_module.py",
+      "memory_path": "ai_modules/habit_tracker_module.py"
+    },
+    {
+      "path": "modules/email_module.py",
+      "memory_path": "ai_modules/email_module.py"
+    },
+    {
+      "path": "modules/files_module.py",
+      "memory_path": "ai_modules/files_module.py"
+    },
+    {
+      "path": "modules/notities_module.py",
+      "memory_path": "ai_modules/notities_module.py"
+    },
+    {
+      "path": "modules/calendar_module.py",
+      "memory_path": "ai_modules/calendar_module.py"
+    },
+    {
+      "path": "modules/highlight_module.py",
+      "memory_path": "ai_modules/highlight_module.py"
+    },
+    {
+      "path": "core/activity_log.json",
+      "memory_path": "core_logic/activity_log.json"
+    },
+    {
+      "path": "core/jaro_link_agent.py",
+      "memory_path": "core_logic/jaro_link_agent.py"
+    },
+    {
+      "path": "core/user_config.py",
+      "memory_path": "core_logic/user_config.py"
+    },
+    {
+      "path": "core/jaro_manifest.py",
+      "memory_path": "core_logic/jaro_manifest.py"
+    },
+    {
+      "path": "core/module_router.py",
+      "memory_path": "core_logic/module_router.py"
+    },
+    {
+      "path": "core/user_config.json",
+      "memory_path": "core_logic/user_config.json"
+    },
+    {
+      "path": "core/backup_config.py",
+      "memory_path": "core_logic/backup_config.py"
+    },
+    {
+      "path": "core/rollback_module.py",
+      "memory_path": "core_logic/rollback_module.py"
+    },
+    {
+      "path": "tests/test_braindump_module.py",
+      "memory_path": "test_routines/test_braindump_module.py"
+    },
+    {
+      "path": "tests/agent_test_log.json",
+      "memory_path": "test_routines/agent_test_log.json"
+    },
+    {
+      "path": "tests/simulate_context_switch.py",
+      "memory_path": "test_routines/simulate_context_switch.py"
+    },
+    {
+      "path": "tests/test_agent_run.py",
+      "memory_path": "test_routines/test_agent_run.py"
+    },
+    {
+      "path": "tests/simulate_context_behavior.py",
+      "memory_path": "test_routines/simulate_context_behavior.py"
+    },
+    {
+      "path": "tools/sync_repo_to_memory.py",
+      "memory_path": "utilities/sync_repo_to_memory.py"
+    },
+    {
+      "path": "tools/export_to_zip.py",
+      "memory_path": "utilities/export_to_zip.py"
+    },
+    {
+      "path": "interface/dashboard.py",
+      "memory_path": "interface_layer/dashboard.py"
+    },
+    {
+      "path": "interface/manifest_debug.py",
+      "memory_path": "interface_layer/manifest_debug.py"
+    },
+    {
+      "path": "interface/dashboard_cli.py",
+      "memory_path": "interface_layer/dashboard_cli.py"
+    },
+    {
+      "path": "interface/config_ui.py",
+      "memory_path": "interface_layer/config_ui.py"
+    },
+    {
+      "path": "interface/main_console.py",
+      "memory_path": "interface_layer/main_console.py"
+    },
+    {
+      "path": "interface/route_debug.py",
+      "memory_path": "interface_layer/route_debug.py"
+    },
+    {
+      "path": "logs/manifest_log.json",
+      "memory_path": "logs/manifest_log.json"
+    },
+    {
+      "path": "logs/user_config_log.json",
+      "memory_path": "logs/user_config_log.json"
+    },
+    {
+      "path": "config/user_profiles.json",
+      "memory_path": "config_profiles/user_profiles.json"
+    },
+    {
+      "path": "config/user_config.json",
+      "memory_path": "config_profiles/user_config.json"
+    },
+    {
+      "path": "config/jaro_visie.json",
+      "memory_path": "config_profiles/jaro_visie.json"
+    },
+    {
+      "path": "data/log_001.json",
+      "memory_path": "data_storage/log_001.json"
+    }
+  ]
+}

--- a/interface/dashboard.py
+++ b/interface/dashboard.py
@@ -29,7 +29,7 @@ def print_dashboard() -> None:
     reflectie = "AAN" if data.get("reflectie") else "UIT"
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    print("\U0001F4BB JARO-TOOTH DASHBOARD")
+    print("\U0001F4BB JARO-CORE DASHBOARD")
     print(f"Gebruiker: {gebruiker}")
     print(f"Context: {context}")
     print(f"Toon: {toon}")

--- a/interface/dashboard_cli.py
+++ b/interface/dashboard_cli.py
@@ -1,4 +1,4 @@
-"""Eenvoudige dashboard CLI voor JARO-TOOTH."""
+"""Eenvoudige dashboard CLI voor JARO-CORE."""
 
 from __future__ import annotations
 
@@ -56,7 +56,7 @@ def _show_dashboard() -> tuple[list[dict], dict]:
         time_str = _format_timestamp(entry.get("timestamp", ""))
         last_line = f"[{time_str}] {entry.get('message', '')}"
 
-    print("\U0001F4E1 JARO-TOOTH DASHBOARD")
+    print("\U0001F4E1 JARO-CORE DASHBOARD")
     print(f"Status: {status}")
     print(f"Actieve modules: {len(active)}")
     print(f"Laatste log: {last_line}")

--- a/modules/braindump_module.py
+++ b/modules/braindump_module.py
@@ -1,4 +1,4 @@
-"""Braindump module voor JARO-TOOTH.
+"""Braindump module voor JARO-CORE.
 
 Wordt geactiveerd in de context 'privé'. De functionaliteit is
 gesimuleerd via een simpel opstartbericht.

--- a/modules/calendar_module.py
+++ b/modules/calendar_module.py
@@ -1,4 +1,4 @@
-"""Simple calendar module for the JARO-TOOTH agent.
+"""Simple calendar module for the JARO-CORE agent.
 
 Provides basic hooks that can be imported by ``jaro_link_agent``.
 

--- a/modules/email_module.py
+++ b/modules/email_module.py
@@ -1,4 +1,4 @@
-"""Simple email module for JARO-TOOTH.
+"""Simple email module for JARO-CORE.
 
 Provides basic communication hooks that can be imported by ``jaro_link_agent``.
 

--- a/modules/files_module.py
+++ b/modules/files_module.py
@@ -1,4 +1,4 @@
-"""Bestandsmodule voor JARO-TOOTH.
+"""Bestandsmodule voor JARO-CORE.
 
 Dit module biedt functionaliteit om bestanden in de datamap te sorteren op basis van hun extensie. De implementatie blijft bewust eenvoudig en uitbreidbaar zodat nieuwe bestandssoorten of acties later kunnen worden toegevoegd.
 

--- a/modules/habit_tracker_module.py
+++ b/modules/habit_tracker_module.py
@@ -1,4 +1,4 @@
-"""Habit tracker module voor de JARO-TOOTH agent.
+"""Habit tracker module voor de JARO-CORE agent.
 
 Dit module legt de basis voor het registreren van gewoontes, het analyseren
 van gedrag en toekomstige integraties met agenda's of herinneringen.

--- a/modules/highlight_module.py
+++ b/modules/highlight_module.py
@@ -1,4 +1,4 @@
-"""Highlight module voor JARO-TOOTH.
+"""Highlight module voor JARO-CORE.
 
 Deze eenvoudige variant drukt enkel een bevestiging bij het starten
 en kan later uitgebreid worden met echte functionaliteit.

--- a/modules/notities_module.py
+++ b/modules/notities_module.py
@@ -1,4 +1,4 @@
-"""Notities module voor JARO-TOOTH.
+"""Notities module voor JARO-CORE.
 
 Deze minimale implementatie wordt gebruikt om context switching te
 demonstreren. Bij het starten toont de module enkel een bericht.

--- a/tests/simulate_context_switch.py
+++ b/tests/simulate_context_switch.py
@@ -1,4 +1,4 @@
-"""Simulatiescript voor het wisselen van contexten in JARO-TOOTH.
+"""Simulatiescript voor het wisselen van contexten in JARO-CORE.
 
 Het script demonstreert de nieuwe CLI-commando's ``switch_context`` en
 ``revert_context`` en toont welke modules per context worden gestart.

--- a/tools/export_to_zip.py
+++ b/tools/export_to_zip.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Create distribution ZIP for jaro_tooth project."""
+"""Create distribution ZIP for jaro_core project."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ def generate_requirements() -> str:
 
 def main() -> None:
     base = project_root()
-    output_zip = base / 'jaro_tooth_release_v1.zip'
+    output_zip = base / 'jaro_core_release_v1.zip'
 
     with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for item in ['core', 'modules', 'config', 'interface', 'tests']:

--- a/tools/sync_repo_to_memory.py
+++ b/tools/sync_repo_to_memory.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+"""Index repository files for potential memory sync."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+OUTPUT_FILE = REPO_ROOT / "data" / "log_001.json"
+FILE_TYPES = {".py", ".json", ".md", ".csv", ".xlsx", ".ics"}
+
+SYNC_MAP = {
+    "config": "config_profiles",
+    "core": "core_logic",
+    "data": "data_storage",
+    "interface": "interface_layer",
+    "modules": "ai_modules",
+    "tests": "test_routines",
+    "tools": "utilities",
+}
+
+
+def index_repo() -> List[Dict[str, str]]:
+    entries: List[Dict[str, str]] = []
+    for path in REPO_ROOT.rglob("*"):
+        if any(part.startswith(".") for part in path.parts):
+            continue
+        if path.is_file() and path.suffix.lower() in FILE_TYPES:
+            rel = path.relative_to(REPO_ROOT)
+            parts = rel.parts
+            if parts:
+                top = parts[0]
+                memory_dir = SYNC_MAP.get(top)
+                if memory_dir:
+                    memory_path = Path(memory_dir).joinpath(*parts[1:])
+                else:
+                    memory_path = rel
+            else:
+                memory_path = rel
+            entries.append({"path": str(rel), "memory_path": str(memory_path)})
+    return entries
+
+
+def main() -> None:
+    data = {
+        "memory_name": "jasper_vonk_core",
+        "generated": datetime.utcnow().isoformat() + "Z",
+        "files": index_repo(),
+    }
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+    print(f"Index saved to {OUTPUT_FILE}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rename JARO-TOOTH references to JARO-CORE
- add `sync_repo_to_memory.py` utility script
- generate initial `data/log_001.json`
- adjust release packaging script and docs

## Testing
- `pytest -q`
- `tools/sync_repo_to_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6879884f39cc832ca48a795d24d4c1be