### PR TITLE
Add Notion module

### DIFF
--- a/ai_modules/notion_module.py
+++ b/ai_modules/notion_module.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+NOTION_KEY = os.environ.get("NOTION_KEY", "")
+HEADERS = {
+    "Authorization": f"Bearer {NOTION_KEY}",
+    "Notion-Version": "2022-06-28",
+    "Content-Type": "application/json",
+}
+
+LOG_FILE = Path(__file__).resolve().parent.parent / "data" / "log_002.json"
+
+
+def _append_log(action: str, info: Dict) -> None:
+    """Append an entry to the feedback log under a note reference."""
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        entries = json.loads(LOG_FILE.read_text()) if LOG_FILE.exists() else []
+    except json.JSONDecodeError:
+        entries = []
+    note_id = f"note_{len(entries) + 1:03d}"
+    entries.append({"note_ref": note_id, "action": action, "info": info})
+    LOG_FILE.write_text(json.dumps(entries, indent=2, ensure_ascii=False))
+
+
+def read_notion_database(database_id: str) -> List[dict]:
+    """Return items from a Notion database."""
+    url = f"https://api.notion.com/v1/databases/{database_id}/query"
+    logger.debug("Reading Notion database %s", database_id)
+    response = requests.post(url, headers=HEADERS)
+    if response.status_code != 200:
+        logger.error("Failed to read Notion database: %s", response.text)
+        _append_log("read_failed", {"database_id": database_id, "status": response.status_code})
+        return []
+    results = response.json().get("results", [])
+    _append_log("read_database", {"database_id": database_id, "count": len(results)})
+    return results
+
+
+def update_notion_page(page_id: str, properties: Dict) -> bool:
+    """Update a Notion page with new properties."""
+    url = f"https://api.notion.com/v1/pages/{page_id}"
+    logger.debug("Updating Notion page %s", page_id)
+    response = requests.patch(url, headers=HEADERS, json={"properties": properties})
+    success = response.status_code == 200
+    if not success:
+        logger.error("Failed to update Notion page: %s", response.text)
+    _append_log("update_page", {"page_id": page_id, "success": success})
+    return success

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 openpyxl
+python-dotenv
+requests

--- a/tests/test_notion_module.py
+++ b/tests/test_notion_module.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, BASE_DIR)
+
+from ai_modules import notion_module
+
+
+def test_read_notion_database(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOTION_KEY", "test-key")
+    log_file = tmp_path / "log_002.json"
+    monkeypatch.setattr(notion_module, "LOG_FILE", log_file)
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = {"results": [{"id": "123"}]}
+
+    with patch("requests.post", return_value=resp) as post:
+        data = notion_module.read_notion_database("dbid")
+        assert data == [{"id": "123"}]
+        post.assert_called_once()
+
+    logged = json.loads(log_file.read_text())
+    assert logged and logged[0]["note_ref"] == "note_001"
+
+
+def test_update_notion_page(tmp_path, monkeypatch):
+    monkeypatch.setenv("NOTION_KEY", "test-key")
+    log_file = tmp_path / "log_002.json"
+    monkeypatch.setattr(notion_module, "LOG_FILE", log_file)
+
+    resp = MagicMock()
+    resp.status_code = 200
+
+    with patch("requests.patch", return_value=resp) as pat:
+        success = notion_module.update_notion_page("pageid", {"Title": {}})
+        assert success
+        pat.assert_called_once()
+
+    logged = json.loads(log_file.read_text())
+    assert logged and logged[0]["note_ref"] == "note_001"


### PR DESCRIPTION
## Summary
- implement Notion helper module in `ai_modules`
- support reading/updating via Notion API and log to `data/log_002.json`
- add tests for Notion module
- update `requirements.txt` for `python-dotenv` and `requests`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879943a2f70832ca289ac706a75be27