### PR TITLE
Add Gmail module with OAuth2 integration

### DIFF
--- a/ai_modules/gmail_module.py
+++ b/ai_modules/gmail_module.py
@@ -1,0 +1,29 @@
+"""Gmail integration via OAuth2."""
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from utilities.config_loader import load_google_credentials
+
+
+def get_gmail_service():
+    """Return an authorized Gmail service instance."""
+    creds_data = load_google_credentials()
+    creds = Credentials.from_authorized_user_info(info=creds_data)
+    service = build("gmail", "v1", credentials=creds)
+    return service
+
+
+def send_email(to: str, subject: str, body: str):
+    """Send an email via the Gmail API."""
+    service = get_gmail_service()
+    message = {
+        "raw": body.encode("utf-8").decode("utf-8")
+    }
+    return (
+        service.users()
+        .messages()
+        .send(userId="me", body=message)
+        .execute()
+    )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+google-api-python-client
+google-auth
 openpyxl
 python-dotenv
 requests

--- a/tests/test_gmail_module.py
+++ b/tests/test_gmail_module.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from ai_modules import gmail_module
+
+
+def test_get_gmail_service(monkeypatch):
+    creds_info = {"token": "abc"}
+    monkeypatch.setattr(
+        gmail_module, "load_google_credentials", lambda: creds_info
+    )
+
+    creds_obj = MagicMock()
+    with patch.object(gmail_module.Credentials, "from_authorized_user_info", return_value=creds_obj) as cred_patch:
+        with patch.object(gmail_module, "build", return_value="service") as build_patch:
+            service = gmail_module.get_gmail_service()
+            assert service == "service"
+            cred_patch.assert_called_once_with(info=creds_info)
+            build_patch.assert_called_once_with("gmail", "v1", credentials=creds_obj)
+
+
+def test_send_email(monkeypatch):
+    service_mock = MagicMock()
+    users = service_mock.users.return_value
+    messages = users.messages.return_value
+    send = messages.send.return_value
+    send.execute.return_value = {"id": "123"}
+
+    monkeypatch.setattr(gmail_module, "get_gmail_service", lambda: service_mock)
+
+    result = gmail_module.send_email("to", "subject", "body")
+    assert result == {"id": "123"}
+    users.messages.assert_called_once()
+    messages.send.assert_called_once()
+    send.execute.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add Gmail module to talk to Gmail API using OAuth2 credentials
- install google-auth and google-api-python-client dependencies
- test gmail module functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aad9d86e0832cb73ab81adcb56a01