### PR TITLE
Add OAuth2 security recommendations doc

### DIFF
--- a/docs/security_recommendations.md
+++ b/docs/security_recommendations.md
@@ -1,0 +1,10 @@
+# OAuth2 Veiligheidsadvies
+
+- Gebruik alleen OAuth2 scopes die strikt noodzakelijk zijn (`gmail.send`, `gmail.readonly`).
+- Beperk tokenlevensduur via Google Cloud Console.
+- Sla tokens nooit hardcoded op in Python-scripts.
+- Zet `GOOGLE_CREDENTIALS_PATH` in `.env` en gebruik `.gitignore`.
+- Beperk toegang tot credentials via chmod 600.
+- Activeer alerts bij verdachte login-activiteit.
+
+Gebruik de integriteitscheck (`tools/system_diagnostics.py`) regelmatig als healthcheck.


### PR DESCRIPTION
## Summary
- document OAuth2 best practices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aafd68504832cb5388cd3671c35ea