### PR TITLE
Add security module and registry

### DIFF
--- a/ai_modules/security_module.py
+++ b/ai_modules/security_module.py
@@ -1,0 +1,46 @@
+"""Security monitoring module for JARO-CORE.
+
+This lightweight module logs security events and provides
+an overview of enabled GitHub security features.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+
+__all__ = []
+
+logger = logging.getLogger(__name__)
+
+LOG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "data", "security_log.json")
+
+
+def start() -> None:
+    """Initialize the security module."""
+    logger.debug("Security module start() called")
+    print("\U0001F6E1\uFE0F Security module gestart")
+
+
+def log_event(message: str) -> None:
+    """Append a security event to ``security_log.json``."""
+    entry = {"timestamp": datetime.utcnow().isoformat() + "Z", "message": message}
+    logs = []
+    if os.path.exists(LOG_FILE):
+        try:
+            with open(LOG_FILE, "r", encoding="utf-8") as f:
+                logs = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            logs = []
+    logs.append(entry)
+    with open(LOG_FILE, "w", encoding="utf-8") as f:
+        json.dump(logs, f, indent=2, ensure_ascii=False)
+
+
+def show_overview() -> None:
+    """Print a summary of GitHub security features in use."""
+    print(
+        "Security features: Security Policy, CodeQL scanning, Private Vulnerability Reporting, Secret scanning."
+    )

--- a/config_profiles/module_registry.json
+++ b/config_profiles/module_registry.json
@@ -1,0 +1,15 @@
+{
+  "modules": {
+    "security_module": {
+      "path": "ai_modules/security_module.py",
+      "status": "actief",
+      "tags": ["security", "monitoring", "github", "codeql", "logging"],
+      "linked_files": [
+        "SECURITY.md",
+        "security_overview.md",
+        ".github/workflows/codeql.yml"
+      ]
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `security_module` for logging basic security events
- track module information in `config_profiles/module_registry.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687adf8113e4832cbdc0757c49d1d412