### PR TITLE
Add Gmail client and connection test utility

### DIFF
--- a/modules/email/gmail_client.py
+++ b/modules/email/gmail_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+
+from utilities.config_loader import load_google_credentials
+
+
+class GmailClient:
+    """Lightweight Gmail API client."""
+
+    def __init__(self, creds_info: dict | None = None):
+        try:
+            creds_data = creds_info or load_google_credentials()
+        except FileNotFoundError:
+            self.service = None
+        else:
+            creds = Credentials.from_authorized_user_info(info=creds_data)
+            self.service = build("gmail", "v1", credentials=creds)
+
+    def send_email(self, to: str, subject: str, body: str) -> dict:
+        """Send an email via the Gmail API."""
+        if not self.service:
+            raise RuntimeError("Gmail service not initialized")
+        message = {"raw": body.encode("utf-8").decode("utf-8")}
+        return (
+            self.service.users()
+            .messages()
+            .send(userId="me", body=message)
+            .execute()
+        )
+
+
+__all__ = ["GmailClient"]

--- a/test_gmail_connection.py
+++ b/test_gmail_connection.py
@@ -1,0 +1,13 @@
+from modules.email.gmail_client import GmailClient
+
+
+def test_connection():
+    gmail = GmailClient()
+    if gmail.service:
+        print("✅ Gmail verbinding succesvol!")
+    else:
+        print("❌ Gmail verbinding mislukt.")
+
+
+if __name__ == "__main__":
+    test_connection()


### PR DESCRIPTION
## Summary
- create `GmailClient` wrapper around the Gmail API
- add `test_gmail_connection.py` helper script
- ensure existing tests continue to pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687af3eef9fc832c85a54026871032cb