### PR TITLE
Add Gmail security alert with log attachment

### DIFF
--- a/core/gmail_client.py
+++ b/core/gmail_client.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+
+from modules.email.gmail_client import GmailClient
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+LOG_FILE = ROOT_DIR / "logs" / "security_log.json"
+
+
+def _append_log(entry: dict) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if LOG_FILE.exists():
+        try:
+            data = json.loads(LOG_FILE.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            data = []
+    else:
+        data = []
+    data.append(entry)
+    LOG_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False))
+
+
+def send_security_alert(subject: str, message: str, attachment_path: str | None = None) -> dict:
+    """Send a security alert email via Gmail OAuth2 and log the event."""
+    gmail = GmailClient()
+    if not gmail.service:
+        raise RuntimeError("Gmail service not initialized")
+
+    email_msg = EmailMessage()
+    email_msg["To"] = "me"
+    email_msg["Subject"] = subject
+    email_msg.set_content(message)
+
+    if attachment_path:
+        path = Path(attachment_path)
+        if path.is_file():
+            email_msg.add_attachment(
+                path.read_bytes(),
+                maintype="application",
+                subtype="octet-stream",
+                filename=path.name,
+            )
+
+    encoded = base64.urlsafe_b64encode(email_msg.as_bytes()).decode()
+    response = (
+        gmail.service.users()
+        .messages()
+        .send(userId="me", body={"raw": encoded})
+        .execute()
+    )
+
+    _append_log(
+        {
+            "timestamp": datetime.now().isoformat(),
+            "event": "security_alert_sent",
+            "subject": subject,
+            "attachment": str(attachment_path) if attachment_path else None,
+        }
+    )
+    return response
+
+
+__all__ = ["send_security_alert"]

--- a/tests/test_security_alert.py
+++ b/tests/test_security_alert.py
@@ -1,0 +1,27 @@
+import json
+from unittest.mock import MagicMock
+
+from core import gmail_client
+
+
+def test_send_security_alert(tmp_path, monkeypatch):
+    service_mock = MagicMock()
+    users = service_mock.users.return_value
+    messages = users.messages.return_value
+    send = messages.send.return_value
+    send.execute.return_value = {"id": "1"}
+
+    class DummyClient:
+        def __init__(self):
+            self.service = service_mock
+
+    monkeypatch.setattr(gmail_client, "GmailClient", DummyClient)
+    log_file = tmp_path / "security.json"
+    monkeypatch.setattr(gmail_client, "LOG_FILE", log_file)
+
+    res = gmail_client.send_security_alert("subject", "msg")
+    assert res == {"id": "1"}
+    send.execute.assert_called_once()
+
+    logged = json.loads(log_file.read_text())
+    assert logged and logged[0]["event"] == "security_alert_sent"

--- a/tools/clean_git_secrets.py
+++ b/tools/clean_git_secrets.py
@@ -10,9 +10,9 @@ from subprocess import run, PIPE
 
 # Optional Gmail notification
 try:
-    from modules.email.gmail_client import GmailClient
+    from core.gmail_client import send_security_alert
 except Exception:  # pragma: no cover - optional dependency
-    GmailClient = None
+    send_security_alert = None
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 LOG_FILE = ROOT_DIR / "logs" / "security_log.json"
@@ -54,16 +54,14 @@ def _append_log(entry: dict) -> None:
 
 
 def _notify_via_email() -> None:
-    if not GmailClient:
+    if not send_security_alert:
         return
     try:
-        gmail = GmailClient()
-        if gmail.service:
-            gmail.send_email(
-                to="me",
-                subject="Beveiligingsincident gedetecteerd",
-                body="Beveiligingsincident gedetecteerd – zie logs/security_log.json",
-            )
+        send_security_alert(
+            subject="\U0001F6A8 Git Secret Detectie",
+            message="Beveiligingsincident gedetecteerd – zie bijlage.",
+            attachment_path=str(LOG_FILE),
+        )
     except Exception as exc:  # pragma: no cover - best effort
         print(f"E-mailmelding mislukt: {exc}")
 


### PR DESCRIPTION
## Summary
- send security alert emails through new `core.gmail_client.send_security_alert`
- use this alert in `tools/clean_git_secrets.py`
- log alert events to `logs/security_log.json`
- test the new alert functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b01c9b350832cb8f5f34cef316711