### PR TITLE
Add tests for Notion helper functions

### DIFF
--- a/ai_modules/helpers/notion_helper.py
+++ b/ai_modules/helpers/notion_helper.py
@@ -59,3 +59,12 @@ def get_page(page_id: str) -> Optional[dict]:
         logger.error("Failed to fetch page: %s", resp.text)
         return None
     return resp.json()
+
+
+def fetch_all_tasks() -> List[dict]:
+    """Fetch all tasks from the configured Notion tasks database."""
+    database_id = os.environ.get("NOTION_DATABASE_ID_TASKS", "")
+    if not database_id:
+        logger.warning("NOTION_DATABASE_ID_TASKS not set")
+        return []
+    return query_database(database_id)


### PR DESCRIPTION
## Summary
- add `fetch_all_tasks` to Notion helper
- extend notion tests for create_page, update_page and fetch_all_tasks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b06e609d8832cbdd6acb2f68d7ddc